### PR TITLE
update: support multiple domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,7 @@ Updates your Duck DNS IP address automatically at the frequency specified. Use `
 ## Variables
 
 * `DUCKDNS_TOKEN`: Duck DNS account token (obtained from [Duck DNS](https://www.duckdns.org))
-* `DUCKDNS_DOMAIN`: Full Duck DNS domain (e.g. `test.duckdns.org`)
+* `DUCKDNS_DOMAIN`: Full Duck DNS domain (e.g. `test.duckdns.org`).
+  * Multiple domains **belonging to the same token** can be entered as a comma-separated list
+  of values (e.g. `test1.duckdns.org,test2.duckdns.org`).
 * `DUCKDNS_DELAY`: Delay between IP address updates

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,31 +1,39 @@
 #!/bin/sh
 
-# Extract subdomain from DUCKDNS_DOMAIN
-DUCKDNS_SUBDOMAIN=$(echo $DUCKDNS_DOMAIN | tr '.' '\n' | head -n 1)
+OLD_IFS="$IFS"
+IFS=','
+set -- $DUCKDNS_DOMAIN
+IFS="$OLD_IFS"
 
-# Check if subdomain extraction failed
-if [ -z "$DUCKDNS_SUBDOMAIN" ]; then
-  echo ERROR: Invalid value for DUCKDNS_DOMAIN
-  exit 1
-fi
+# Loop through each domain in the positional parameters
+for domain in "$@"; do
+    # Extract subdomain from current domain
+    DUCKDNS_SUBDOMAIN=$(echo "$domain" | tr '.' '\n' | head -n 1)
 
-# Loop update process
-while :; do
-  echo url="https://www.duckdns.org/update?domains=${DUCKDNS_SUBDOMAIN}&token=${DUCKDNS_TOKEN}&ip=" | curl -ks -o /scripts/duck.log -K -
+    # Check if subdomain extraction failed for the current domain
+    if [ -z "$DUCKDNS_SUBDOMAIN" ]; then
+        echo "ERROR: Invalid value for DUCKDNS_DOMAIN: $domain"
+        exit 1
+    fi
 
-  # Check that log was created (successful curl) and
-  if [ ! -f "/scripts/duck.log" ]; then
-    echo ERROR: Failed to create Duck DNS log file, check your TOKEN and DOMAIN
-    exit 1
-  fi
+    # Loop update process
+    while :; do
+    echo url="https://www.duckdns.org/update?domains=${DUCKDNS_SUBDOMAIN}&token=${DUCKDNS_TOKEN}&ip=" | curl -ks -o /scripts/duck.log -K -
 
-  if [ "$(cat /scripts/duck.log)" != "OK" ]; then
-    echo ERROR: IP address update failed, check your TOKEN and DOMAIN
-    exit 1
-  fi
+    # Check that log was created (successful curl) and
+    if [ ! -f "/scripts/duck.log" ]; then
+        echo ERROR: Failed to create Duck DNS log file, check your TOKEN and DOMAIN
+        exit 1
+    fi
 
-  # Wait before updating ip address again
-  echo Successfully updated IP address
-  echo Sleeping for $DUCKDNS_DELAY minute\(s\)
-  sleep $((${DUCKDNS_DELAY} * 60))
+    if [ "$(cat /scripts/duck.log)" != "OK" ]; then
+        echo ERROR: IP address update failed, check your TOKEN and DOMAIN
+        exit 1
+    fi
+
+    # Wait before updating ip address again
+    echo Successfully updated IP address
+    echo Sleeping for $DUCKDNS_DELAY minute\(s\)
+    sleep $((${DUCKDNS_DELAY} * 60))
+    done
 done


### PR DESCRIPTION
Support multiple domains as a comma-separated list of values.

This would also pair perfectly with https://github.com/maksimstojkovic/docker-letsencrypt, since `certbot` natively support multiple domains with this same comma-separated format.

Note that when adding support for multiple domains here, also https://github.com/maksimstojkovic/docker-letsencrypt/pull/10 is required.